### PR TITLE
Remove warning messages

### DIFF
--- a/surveygizmo/api/base.py
+++ b/surveygizmo/api/base.py
@@ -1,8 +1,10 @@
-
 import hashlib
 
 import requests
+import requests.packages.urllib3
 from surveygizmo import oauth_helper
+
+requests.packages.urllib3.disable_warnings()
 
 
 class Resource(object):


### PR DESCRIPTION
- This PR removes warning messages in urllib3

```
/usr/local/lib/python2.7/dist-packages/requests/packages/urllib3
/util/ssl_.py:79: InsecurePlatformWarning: A true SSLContext object is not
available. This prevents urllib3 from configuring SSL appropriately and 
may cause certain SSL connections to fail. For more information, see 
https://urllib3.readthedocs.org/en/latest  
/security.html#insecureplatformwarning.
```

More info [here](https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings)
