### PR TITLE
needs recent version of requests python lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 rauth==0.5.5
-requests==1.2.3
+requests==2.11.1


### PR DESCRIPTION
- in order do disable que urllib3 SSL warning message we need to have a higher version of the requests lib
