### PR TITLE
Explicit added the latest version of rauth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     keywords="Survey Gizmo SurveyGizmo surveygizmo",
     url='https://github.com/rpkilby/SurveyGizmo/',
     packages=find_packages(),
-    install_requires=['requests==2.11.1', 'rauth'],
+    install_requires=['requests==2.11.1', 'rauth==0.7.2'],
     license='BSD License',
     classifiers=(
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
- rauth depends on requests, so does SurveyGizmo, not specifying the version of rauth makes the setup fetch an older version of requests, which causes SurveyGizmo to break
